### PR TITLE
Organization creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,3 @@ DEPENDENCIES
   sqlite3
   timecop
   unicorn
-
-BUNDLED WITH
-   1.10.6

--- a/app/admin/organizations.rb
+++ b/app/admin/organizations.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register Organization do
+  permit_params :name, :facebook_id
+
+  filter :name, :as => :string
+  filter :mission, :as => :string
+
+  index do
+    selectable_column
+    id_column
+    column :facebook_id
+    column :name
+    column :mission
+    column :created_at
+    column :cached_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :facebook_id
+      row :name
+      row :mission
+      row :state
+      row :city
+      row :zip
+      row :street
+      row :picture do
+        image_tag resource.picture
+      end
+      row :cached_at
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  after_create { UpdateOrganizationJob.perform_later(resource) }
+
+  form do |f|
+    f.semantic_errors
+    f.inputs "Organization details" do
+      input :facebook_id
+    end
+    f.actions
+  end
+end


### PR DESCRIPTION
Create ActiveAdmin resource for Organizations. Admins can add organizations just by adding organization's facebook id.

![givdo-dashboard-organizations-create](https://cloud.githubusercontent.com/assets/624418/13939087/4b3213f6-efb0-11e5-8e05-0f3eeb3eb282.gif)
