### PR TITLE
Cycles and Current Scores dashboards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'sqlite3'
   gem 'rspec-rails'
   gem 'timecop'
+  gem 'database_cleaner'
   gem 'factory_girl_rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.0)
+    database_cleaner (1.5.1)
     devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -252,6 +253,7 @@ DEPENDENCIES
   activeadmin!
   annotate
   byebug
+  database_cleaner
   devise
   factory_girl_rails
   jwt

--- a/app/admin/cycles.rb
+++ b/app/admin/cycles.rb
@@ -1,0 +1,40 @@
+ActiveAdmin.register Cycle do
+  config.batch_actions = false
+
+  filter :ended_at, default: true
+  filter :created_at
+
+  actions :all, except: [:new, :create, :edit, :update, :show]
+
+  index do
+    id_column
+    column :created_at
+    column :ended_at
+    column :score
+    actions defaults: false do |cycle|
+      link_to 'Stop', stop_admin_cycle_path(cycle), method: :put if cycle.started?
+    end
+  end
+
+  action_item :start, only: :index do
+    link_to 'Start cycle', start_admin_cycles_path
+  end
+
+  collection_action :start, method: :get do
+    Cycle::Start.call
+
+    redirect_to collection_path, notice: 'New cycle started!'
+  end
+
+  member_action :stop, method: :put do
+    StopCycleJob.perform_later(resource.id)
+
+    redirect_to collection_path, notice: 'Cycle stoped!'
+  end
+
+  controller do
+    def current_cycle
+      @current_cycle || Cycle.current
+    end
+  end
+end

--- a/app/admin/scores.rb
+++ b/app/admin/scores.rb
@@ -1,11 +1,12 @@
-ActiveAdmin.register Organization, as: 'Scores' do
+ActiveAdmin.register Organization, as: 'Current Scores' do
   actions :all, except: [:new, :create, :edit, :update]
 
   filter :name, :as => :string
 
   controller do
     def scoped_collection
-      Organization.with_score
+      current_cycle = Cycle.current
+      Organization.scores_between(current_cycle.created_at, Time.current)
     end
   end
 

--- a/app/jobs/stop_cycle_job.rb
+++ b/app/jobs/stop_cycle_job.rb
@@ -1,0 +1,8 @@
+class StopCycleJob < ActiveJob::Base
+  queue_as :urgent
+
+  def perform(cycle_id)
+    cycle = Cycle.find(cycle_id)
+    Cycle::Stop.call(cycle)
+  end
+end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: cycles
+#
+#  id         :integer          not null, primary key
+#  ended_at   :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Cycle < ActiveRecord::Base
+  has_many :scores, class_name: 'Cycle::Score'
+
+  scope :ended, -> { where.not(ended_at: nil) }
+
+  def self.current
+    where(ended_at: nil).last
+  end
+
+  def stop!
+    update_attribute(:ended_at, Time.current)
+  end
+
+  def score
+    scores.sum(:score)
+  end
+
+  def stoped?
+    ended_at.present?
+  end
+
+  def started?
+    !stoped?
+  end
+end

--- a/app/models/cycle/score.rb
+++ b/app/models/cycle/score.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: cycle_scores
+#
+#  id              :integer          not null, primary key
+#  score           :integer
+#  cycle_id        :integer
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_cycle_scores_on_cycle_id         (cycle_id)
+#  index_cycle_scores_on_organization_id  (organization_id)
+#
+
+class Cycle::Score < ActiveRecord::Base
+  belongs_to :cycleg
+  belongs_to :organization
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,8 +23,14 @@ class Organization < ActiveRecord::Base
 
   def self.with_score
     joins(:players)
-    .select('organizations.*, SUM(players.score) AS total_score')
-    .group('organizations.id')
+      .select('organizations.*, SUM(players.score) AS total_score')
+      .merge(Player.finished)
+      .group('organizations.id')
+  end
+
+  def self.scores_between(start_date, end_date)
+    self.with_score
+      .where('players.created_at BETWEEN ? AND ?', start_date, end_date)
   end
 
   def cache!

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -24,6 +24,8 @@ class Player < ActiveRecord::Base
   belongs_to :organization
   has_many :answers
 
+  scope :finished, -> { where.not(players: { finished_at: nil }) }
+
   def has_rounds?
     rounds_left > 0
   end

--- a/app/services/cycle/create_scores.rb
+++ b/app/services/cycle/create_scores.rb
@@ -1,0 +1,11 @@
+class Cycle::CreateScores
+  def self.call(cycle)
+    return unless cycle.stoped?
+
+    organizations = Organization.scores_between(cycle.created_at, cycle.ended_at)
+
+    organizations.find_each do |org|
+      cycle.scores << Cycle::Score.create(organization: org, score: org.total_score)
+    end
+  end
+end

--- a/app/services/cycle/start.rb
+++ b/app/services/cycle/start.rb
@@ -1,0 +1,6 @@
+class Cycle::Start
+  def self.call
+    Cycle::Stop.call(Cycle.current)
+    Cycle::create!
+  end
+end

--- a/app/services/cycle/stop.rb
+++ b/app/services/cycle/stop.rb
@@ -1,0 +1,10 @@
+class Cycle::Stop
+  def self.call(cycle)
+    return if cycle.blank?
+    
+    ActiveRecord::Base.transaction do
+      cycle.stop!
+      Cycle::CreateScores.call(cycle)
+    end
+  end
+end

--- a/db/migrate/20160329011116_create_cycles.rb
+++ b/db/migrate/20160329011116_create_cycles.rb
@@ -1,0 +1,9 @@
+class CreateCycles < ActiveRecord::Migration
+  def change
+    create_table :cycles do |t|
+      t.datetime :ended_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160329220000_create_cycle_scores.rb
+++ b/db/migrate/20160329220000_create_cycle_scores.rb
@@ -1,0 +1,11 @@
+class CreateCycleScores < ActiveRecord::Migration
+  def change
+    create_table :cycle_scores do |t|
+      t.integer :score
+      t.belongs_to :cycle, foreign_key: true, index: true
+      t.belongs_to :organization, foreign_key: true, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160310180301) do
+ActiveRecord::Schema.define(version: 20160329220000) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -68,6 +68,23 @@ ActiveRecord::Schema.define(version: 20160310180301) do
     t.string "name"
   end
 
+  create_table "cycle_scores", force: :cascade do |t|
+    t.integer  "score"
+    t.integer  "cycle_id"
+    t.integer  "organization_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "cycle_scores", ["cycle_id"], name: "index_cycle_scores_on_cycle_id"
+  add_index "cycle_scores", ["organization_id"], name: "index_cycle_scores_on_organization_id"
+
+  create_table "cycles", force: :cascade do |t|
+    t.datetime "ended_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "games", force: :cascade do |t|
     t.integer  "creator_id"
     t.datetime "created_at",                 null: false
@@ -90,6 +107,15 @@ ActiveRecord::Schema.define(version: 20160310180301) do
 
   add_index "games_users", ["game_id"], name: "index_games_users_on_game_id"
   add_index "games_users", ["user_id"], name: "index_games_users_on_user_id"
+
+  create_table "organization_score_reports", force: :cascade do |t|
+    t.integer  "score"
+    t.integer  "organization_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "organization_score_reports", ["organization_id"], name: "index_organization_score_reports_on_organization_id"
 
   create_table "organizations", force: :cascade do |t|
     t.string   "facebook_id"

--- a/spec/jobs/stop_cycle_job_spec.rb
+++ b/spec/jobs/stop_cycle_job_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe StopCycleJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.new.perform(cycle.id) }
+
+  let(:cycle) { create(:cycle, ended_at: nil) }
+end

--- a/spec/models/cycle/score_spec.rb
+++ b/spec/models/cycle/score_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Cycle::Score, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/cycle_spec.rb
+++ b/spec/models/cycle_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Cycle, type: :model do
+  describe '#stop!' do
+    it 'updates ended_at to now' do
+      Timecop.freeze
+      cycle = create(:cycle, ended_at: nil)
+
+      cycle.stop!
+      cycle.reload
+
+      expect(cycle.ended_at).to eq(Time.current)
+    end
+  end
+
+  describe ".score" do
+    it 'sums only scores for this cycle' do
+      cycle = create(:cycle, :with_score, scores: 5, cycle_score: 10)
+
+      expect(cycle.score).to eq(50)
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe ".scores_between" do
+    it "calculates scores for players created between the date range" do
+      organization = nil
+      
+      Timecop.travel(1.day.ago) do
+        organization = create(:organization_with_score, score: 10)
+      end
+
+      organizations = described_class.scores_between(2.day.ago, Time.current)
+
+      expect(organizations).to include(organization)
+      expect(organizations.first.total_score).to eq(10)
+    end
+  end
+
   describe '#cache!' do
     it 'stamps the cached time' do
       Timecop.freeze(now = Time.current)

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,8 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Player, :type => :model do
-  let(:user) { subject.user }
   subject { build(:player) }
+
+  let(:user) { subject.user }
+
+  describe ".finished" do
+    it "returns only finished players" do
+      finished_player = create(:player, finished_at: Time.current)
+      unfinished_players = create_list(:player, 3, finished_at: nil)
+
+      players = described_class.finished
+
+      expect(players).to include(finished_player)
+      expect(players).not_to include(unfinished_players)
+    end
+  end
 
   describe '#rounds_left' do
     it 'is the number of rounds a game allows minus the number of rounds the player have played' do

--- a/spec/services/cycle/create_scores_spec.rb
+++ b/spec/services/cycle/create_scores_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Cycle::CreateScores do
+  subject(:service) { described_class }
+
+  it "does nothing if the cycle isn't stoped" do
+    cycle = create(:cycle, ended_at: nil)
+
+    described_class.call(cycle)
+
+    expect(cycle.scores).to be_empty
+  end
+
+  it "calculates scores for the cycle's period" do
+    organization_a = create(:organization)
+    organization_b = create(:organization)
+    cycle = create(:cycle, created_at: 1.month.ago, ended_at: Time.current)
+
+    Timecop.travel(cycle.created_at - 2.days) do
+      create(:finished_player, organization: organization_a, score: 1)
+      create(:finished_player, organization: organization_b, score: 2)
+    end
+
+    Timecop.travel(cycle.created_at + 2.days) do
+      create(:finished_player, organization: organization_a, score: 3)
+      create(:finished_player, organization: organization_b, score: 4)
+    end
+
+    described_class.call(cycle)
+
+    expect(cycle.scores.map(&:score)).to include(3, 4)
+  end
+end

--- a/spec/services/cycle/start_spec.rb
+++ b/spec/services/cycle/start_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Cycle::Start do
+  subject(:service) { described_class }
+
+  it "stops the current cycle if it exists" do
+    current_cycle = build(:cycle, ended_at: nil)
+    allow(Cycle).to receive(:current).and_return(current_cycle)
+
+    expect(Cycle::Stop).to receive(:call).with(current_cycle)
+
+    service.call
+  end
+
+  it "creates a new cycle" do
+    allow(Cycle::Stop).to receive(:call)
+
+    expect(Cycle).to receive(:create!)
+
+    service.call
+  end
+
+  it "returns a cycle" do
+    cycle = build(:cycle)
+    allow(Cycle::Stop).to receive(:call)
+    allow(Cycle).to receive(:create!).and_return(cycle)
+
+    expect(service.call).to eq(cycle)
+  end
+end

--- a/spec/services/cycle/stop_spec.rb
+++ b/spec/services/cycle/stop_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Cycle::Stop do
+  subject(:service) { described_class }
+
+  it "stops the current cycle" do
+    cycle = build(:cycle, ended_at: nil)
+    allow(Cycle::CreateScores).to receive(:call).with(cycle)
+
+    expect(cycle).to receive(:stop!)
+
+    service.call(cycle)
+  end
+
+  it "creates scores for the stoped cycle" do
+    cycle = build(:cycle, ended_at: nil)
+
+    expect(Cycle::CreateScores).to receive(:call).with(cycle)
+
+    service.call(cycle)
+  end
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/support/factories/cycle_scores.rb
+++ b/spec/support/factories/cycle_scores.rb
@@ -1,0 +1,7 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :cycle_score, :class => 'Cycle::Score' do
+    score 0
+  end
+end

--- a/spec/support/factories/cycles.rb
+++ b/spec/support/factories/cycles.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :cycle do
+    trait :current do
+      ended_at nil
+    end
+
+    trait :with_score do
+      ignore do
+        scores 3
+        cycle_score 10
+      end
+
+      after(:create) do |cycle, evalutor|
+        (evalutor.scores).times do
+          cycle.scores << FactoryGirl.create(:cycle_score, score: evalutor.cycle_score)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/factories/organizations.rb
+++ b/spec/support/factories/organizations.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |organization, evalutor|
-        organization.players << FactoryGirl.create(:player, score: evalutor.score)
+        organization.players << FactoryGirl.create(:finished_player, score: evalutor.score)
       end
     end
   end

--- a/spec/support/factories/players.rb
+++ b/spec/support/factories/players.rb
@@ -4,5 +4,9 @@ FactoryGirl.define do
   factory :player do
     user { build(:user) }
     game { build(:game) }
+
+    factory :finished_player do
+      finished_at Time.current
+    end
   end
 end


### PR DESCRIPTION
Cycles dashboard is where admins can stop or start a new cycle.
The `Start cycle` button, stops the current cycle (the one with `ended at` blank), calculates "cycle scores" for each organization with finished players/games, and then creates a new cycle in the database.

The `Stop` button doesn't start a new cycle!

![cycles](https://cloud.githubusercontent.com/assets/624418/14194907/adfa2b64-f789-11e5-851f-e005b33a5a15.png)

Current Scores dashboard presents scores in the current cycle for each organization.
Only organizations with scores in the current cycle are listed here.

![current_scores](https://cloud.githubusercontent.com/assets/624418/14195112/1062492e-f78c-11e5-8a9c-4476b942e7ab.png)
